### PR TITLE
Replaced Symfony2 with Symfony

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -45,7 +45,7 @@ full_title: Bldr Task Runner
                         <a href="http://symfony.com/doc/current/components/dependency_injection/index.html">
                             Dependency Injection Component
                         </a>
-                    </strong> from Sensio's <strong><a href="http://symfony.com">Symfony2 Framework</a></strong>.
+                    </strong> from <strong><a href="http://symfony.com">Symfony Framework</a></strong>.
                     If you want to take a look at how to make a new extension, check out the
                     <a href="http://docs.bldr.io/en/latest/">documentation</a>, on <a href="http://readthedocs.org">Read The Docs</a>.
                 </p>


### PR DESCRIPTION
I’m not sure it it technically “SensioLabs” anymore, so I removed it.